### PR TITLE
Refresh the child pids every 'interval' seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This program uses `journalctl` and `systemctl` to watch for changes in your services, and `top` for metrics about those services, and delivers current status to MQTT. It will also publish Home Assistant MQTT Discovery messages so that (binary) sensors automatically show up in Home Assistant.
 
-The focus lies on long-running services with continuous uptime, instead of single or one-shot services, as the stats are reported every `STATS_RECORD_SECONDS`. For services with a lifespan comparable with this interval, the reported stats will not be accurate as reloading and updating PIDs only happen on service stop/start/restart events. Further, as the library uses `top` and matches the services with their respective PIDs, including PIDs from subprocesses, it is not suited for monitoring services which spawn regularly new threads.
+The focus lies on long-running services with continuous uptime, instead of single or one-shot services, as the stats being reported as well as the child PIDs being refreshed every `STATS_RECORD_SECONDS`. For services with a lifespan comparable to this interval, the reported stats will not be accurate. Further, as the library uses `top` and matches the services with their respective PIDs, including child PIDs from subprocesses, it is not also suited for monitoring services which spawn regularly new threads.
 
 _This is part of a family of similar tools:_
 

--- a/systemctl2mqtt/__init__.py
+++ b/systemctl2mqtt/__init__.py
@@ -38,14 +38,17 @@ from .exceptions import (
 from .systemctl2mqtt import Systemctl2Mqtt
 from .type_definitions import (
     PIDStats,
+    ServiceActiveType,
     ServiceDeviceEntry,
     ServiceEntry,
     ServiceEvent,
     ServiceEventStateType,
     ServiceEventStatusType,
+    ServiceLoadType,
     ServiceStats,
     ServiceStatsRef,
     Systemctl2MqttConfig,
+    SystemctlService,
 )
 
 __all__ = [
@@ -59,6 +62,9 @@ __all__ = [
     "ServiceEventStateType",
     "ServiceEventStatusType",
     "Systemctl2MqttConfig",
+    "SystemctlService",
+    "ServiceLoadType",
+    "ServiceActiveType",
     "LOG_LEVEL_DEFAULT",
     "DESTROYED_SERVICE_TTL_DEFAULT",
     "HOMEASSISTANT_PREFIX_DEFAULT",

--- a/systemctl2mqtt/type_definitions.py
+++ b/systemctl2mqtt/type_definitions.py
@@ -9,6 +9,14 @@ ServiceEventStateType = Literal["on", "off"]
 ServiceEventStatusType = Literal["running", "exited", "failed"]
 """Service event Systemctl status"""
 
+ServiceLoadType = Literal["loaded", "not-found", "error"]
+"""Systemctl service load status"""
+
+ServiceActiveType = Literal["active", "inactive", "failed"]
+"""Systemctl service active status"""
+
+"""Systemctl service sub status"""
+
 
 class Systemctl2MqttConfig(TypedDict):
     """A config object.
@@ -69,6 +77,31 @@ class Systemctl2MqttConfig(TypedDict):
     enable_events: bool
     enable_stats: bool
     stats_record_seconds: int
+
+
+class SystemctlService(TypedDict):
+    """A systemctl service definition.
+
+    Attributes
+    ----------
+    unit
+        The name of the service
+    load
+        Is the service loaded
+    active
+        High level status of the service
+    sub
+        Detailed state of the service
+    description
+        Description of the service
+
+    """
+
+    unit: str
+    load: ServiceLoadType
+    active: ServiceActiveType
+    sub: ServiceEventStatusType
+    description: str
 
 
 class ServiceEvent(TypedDict):


### PR DESCRIPTION
The child pids can change sometimes and as the reported data is sent every `interval`, the child pids are refreshed at the same time. This does **not** work for fast living processes with a lifespan in the same domain as `interval`.