### PR TITLE
Fix parsing of memory values with suffixes from `top`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.1
+
+* Fix parsing of memory values with suffixes from top
+
 ## 1.3.0
 
 * Add option to group all entities into a single device in home assistant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ select = [
     "S317",  # suspicious-xml-sax-usage
     "S318",  # suspicious-xml-mini-dom-usage
     "S319",  # suspicious-xml-pull-dom-usage
-    "S320",  # suspicious-xmle-tree-usage
     "S601",  # paramiko-call
     "S602",  # subprocess-popen-with-shell-equals-true
     "S604",  # call-with-shell-equals-true

--- a/systemctl2mqtt/__init__.py
+++ b/systemctl2mqtt/__init__.py
@@ -1,6 +1,6 @@
 """systemctl2mqtt package."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 from .const import (
     ANSI_ESCAPE,

--- a/systemctl2mqtt/helpers.py
+++ b/systemctl2mqtt/helpers.py
@@ -26,10 +26,9 @@ def clean_for_discovery(
         if isinstance(v, str | int | float | object) and v not in (None, "")
     }
 
+
 def parse_top_size(s: str) -> float:
-    """
-    Parse size string from top (like '8.5g', '512m', '1024k') into float (kilobytes).
-    """
+    """Parse size string from top (like '8.5g', '512m', '1024k') into float (kilobytes)."""
     s = s.strip().lower()
     if s[-1] in "kmgt":
         num = float(s[:-1])

--- a/systemctl2mqtt/helpers.py
+++ b/systemctl2mqtt/helpers.py
@@ -25,3 +25,21 @@ def clean_for_discovery(
         for k, v in dict(val).items()
         if isinstance(v, str | int | float | object) and v not in (None, "")
     }
+
+def parse_top_size(s: str) -> float:
+    """
+    Parse size string from top (like '8.5g', '512m', '1024k') into float (kilobytes).
+    """
+    s = s.strip().lower()
+    if s[-1] in "kmgt":
+        num = float(s[:-1])
+        unit = s[-1]
+        if unit == "k":
+            return num
+        elif unit == "m":
+            return num * 1024**1
+        elif unit == "g":
+            return num * 1024**2
+        elif unit == "t":
+            return num * 1024**3
+    return float(s)  # no suffix

--- a/systemctl2mqtt/systemctl2mqtt.py
+++ b/systemctl2mqtt/systemctl2mqtt.py
@@ -48,7 +48,7 @@ from .exceptions import (
     Systemctl2MqttException,
     Systemctl2MqttStatsException,
 )
-from .helpers import clean_for_discovery
+from .helpers import clean_for_discovery, parse_top_size
 from .type_definitions import (
     PIDStats,
     ServiceDeviceEntry,
@@ -1049,7 +1049,7 @@ class Systemctl2Mqtt:
                             {
                                 "pid": pid,
                                 "cpu": float(stat[8]),
-                                "memory": float(stat[5]) / 1024,  # KB --> MB
+                                "memory": parse_top_size(stat[5]) / 1024,  # KB --> MB
                             }
                         )
                         stats_logger.debug("Printing pid stats: %s", pid_stats)


### PR DESCRIPTION
Previously, systemctl2mqtt failed to correctly parse memory usage values reported by `top` (e.g. "8.5g"). This patch adds proper handling of unit suffixes (k/m/g/t) and converts them into numeric values for consistent processing.