### PR TITLE
Add real memory usage metrics from smaps

### DIFF
--- a/systemctl2mqtt/const.py
+++ b/systemctl2mqtt/const.py
@@ -40,9 +40,32 @@ INVALID_HA_TOPIC_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 ANSI_ESCAPE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 # fmt: off
 STATS_REGISTRATION_ENTRIES = [
-    # label,field,device_class,unit,icon
-    ('CPU',                     'cpu',              None,           '%',    'mdi:chip'),
-    ('Memory',                  'memory',           'data_size',    'MB',   'mdi:memory'),
+    # label,                   field,                       device_class,    unit,   icon,                    catetogy
+    ('CPU',                    'cpu',                       None,            '%',    'mdi:chip',              None),         # CPU utilization percentage
+    ('Memory (Virtual)',       'memory',                    'data_size',     'MB',   'mdi:memory',            None),         # Total virtual memory usage
+    ('Memory (Real)',          'memory_real',               'data_size',     'MB',   'mdi:memory',            None),         # Real memory (calculated from smaps)
+    ('Memory (Real PSS)',      'memory_real_pss',           'data_size',     'MB',   'mdi:memory',            None),         # Real memory (calculated from smaps), based on PSS
+    ('PSS Memory',             'memory_pss',                'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Proportional Set Size (shared pages divided among processes)
+    ('PSS Anon',               'memory_pss_anon',           'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Anonymous memory part of PSS
+    ('PSS File',               'memory_pss_file',           'data_size',     'MB',   'mdi:memory',            "diagnostic"), # File-backed memory part of PSS
+    ('PSS Dirty',              'memory_pss_dirty',          'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Modified (dirty) memory part of PSS
+    ('PSS Shmem',              'memory_pss_shmem',          'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Shared memory part of PSS
+    ('RSS',                    'memory_rss',                'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Resident Set Size (non-swapped physical memory)
+    ('Shared Clean',           'memory_shared_clean',       'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Shared pages not modified (clean)
+    ('Shared Dirty',           'memory_shared_dirty',       'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Shared pages modified (dirty)
+    ('Private Clean',          'memory_private_clean',      'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Private pages that are clean
+    ('Private Dirty',          'memory_private_dirty',      'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Private pages that are dirty
+    ('Referenced',             'memory_referenced',         'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Recently accessed pages
+    ('Anonymous',              'memory_anonymous',          'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Anonymous memory (not file-backed)
+    ('LazyFree',               'memory_lazyfree',           'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Pages marked as free-on-demand (MADV_FREE)
+    ('Anon HugePages',         'memory_anon_hugepages',     'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Anonymous memory using HugePages
+    ('Shmem PMD Mapped',       'memory_shmem_pmd_mapped',   'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Shared memory mapped with hugepages (PMD)
+    ('File PMD Mapped',        'memory_file_pmd_mapped',    'data_size',     'MB',   'mdi:memory',            "diagnostic"), # File-backed memory mapped with hugepages
+    ('Shared HugeTLB',         'memory_shared_hugetlb',     'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Shared HugeTLB memory usage
+    ('Private HugeTLB',        'memory_private_hugetlb',    'data_size',     'MB',   'mdi:memory',            "diagnostic"), # Private HugeTLB memory usage
+    ('Swap',                   'memory_swap',               'data_size',     'MB',   'mdi:swap-horizontal',   "diagnostic"), # Memory swapped out
+    ('Swap PSS',               'memory_swappss',            'data_size',     'MB',   'mdi:swap-horizontal',   "diagnostic"), # Proportional swap usage
+    ('Locked',                 'memory_locked',             'data_size',     'MB',   'mdi:lock',              "diagnostic"), # Locked pages (mlock)
 ]
 # fmt: on
 
@@ -65,6 +88,7 @@ DEFAULT_CONFIG = Systemctl2MqttConfig(
         "service_blacklist": SERVICE_BLACKLIST,
         "enable_events": EVENTS_DEFAULT,
         "enable_stats": STATS_DEFAULT,
+        "enable_smaps": STATS_DEFAULT,
         "stats_record_seconds": STATS_RECORD_SECONDS_DEFAULT,
     }
 )

--- a/systemctl2mqtt/type_definitions.py
+++ b/systemctl2mqtt/type_definitions.py
@@ -57,6 +57,8 @@ class Systemctl2MqttConfig(TypedDict):
         Flag to enable event monitoring
     enable_stats
         Flag to enable stat monitoring
+    enable_smaps
+        Flag to enable smaps memory monitoring (more detailed memory info, but more cpu usage), requires "enable_stats" to be True
     stats_record_seconds
         Interval every how many seconds the stats are published via MQTT
 
@@ -79,6 +81,7 @@ class Systemctl2MqttConfig(TypedDict):
     service_blacklist: list[str]
     enable_events: bool
     enable_stats: bool
+    enable_smaps: bool
     stats_record_seconds: int
 
 
@@ -156,15 +159,88 @@ class PIDStats(TypedDict):
     pid
         The pid of the Service
     memory
-        Used memory in MB
+        Used memory in MB (virtual, from top)
     cpu
         The cpu usage by the Service in cpu-% (ex.: a Systemctl with 4 cores has 400% cpu available)
+    memory_real_pss
+        Real memory in MB (calculated from smaps).
+        Based on Proportional Set Size (PSS): shared pages are divided among processes.
+        Best metric to estimate actual memory footprint of a process
+    memory_real
+        Real memory in MB (calculated from smaps).
+        Memory that will actually be freed if the process exits.
+        Based on Anonymous + SwapPss; shared file-backed pages are excluded, not divided.
+    memory_pss
+        Proportional Set Size in MB
+    memory_pss_anon
+        Anonymous PSS in MB
+    memory_pss_file
+        File-backed PSS in MB
+    memory_pss_dirty
+        Dirty PSS in MB
+    memory_pss_shmem
+        Shared memory PSS in MB
+    memory_rss
+        Resident Set Size in MB
+    memory_shared_clean
+        Shared clean pages in MB
+    memory_shared_dirty
+        Shared dirty pages in MB
+    memory_private_clean
+        Private clean pages in MB
+    memory_private_dirty
+        Private dirty pages in MB
+    memory_referenced
+        Referenced pages in MB
+    memory_anonymous
+        Anonymous memory in MB
+    memory_lazyfree
+        LazyFree pages in MB
+    memory_anon_hugepages
+        Anonymous huge pages in MB
+    memory_shmem_pmd_mapped
+        Shared memory PMD mapped pages in MB
+    memory_file_pmd_mapped
+        File-backed PMD mapped pages in MB
+    memory_shared_hugetlb
+        Shared hugetlb pages in MB
+    memory_private_hugetlb
+        Private hugetlb pages in MB
+    memory_swap
+        Swap in MB
+    memory_swappss
+        Proportional Swap usage in MB
+    memory_locked
+        Locked pages in MB
 
     """
 
     pid: int
     cpu: float
     memory: float
+    memory_real_pss: float
+    memory_real: float
+    memory_pss: float
+    memory_pss_anon: float
+    memory_pss_file: float
+    memory_pss_dirty: float
+    memory_pss_shmem: float
+    memory_rss: float
+    memory_shared_clean: float
+    memory_shared_dirty: float
+    memory_private_clean: float
+    memory_private_dirty: float
+    memory_referenced: float
+    memory_anonymous: float
+    memory_lazyfree: float
+    memory_anon_hugepages: float
+    memory_shmem_pmd_mapped: float
+    memory_file_pmd_mapped: float
+    memory_shared_hugetlb: float
+    memory_private_hugetlb: float
+    memory_swap: float
+    memory_swappss: float
+    memory_locked: float
 
 
 class ServiceStats(TypedDict):
@@ -177,11 +253,61 @@ class ServiceStats(TypedDict):
     host
         The Systemctl host
     memory
-        Used memory in MB
+        Used memory in MB (virtual, from top)
     cpu
         The cpu usage by the Service in cpu-% (ex.: a Systemctl with 4 cores has 400% cpu available)
     pid_stats
         The stats for all pids
+    memory_real_pss
+        Real memory in MB (calculated from smaps).
+        Based on Proportional Set Size (PSS): shared pages are divided among processes.
+        Best metric to estimate actual memory footprint of a process
+    memory_real
+        Real memory in MB (calculated from smaps).
+        Memory that will actually be freed if the process exits.
+        Based on Anonymous + SwapPss; shared file-backed pages are excluded, not divided.
+    memory_pss
+        Proportional Set Size in MB
+    memory_pss_anon
+        Anonymous PSS in MB
+    memory_pss_file
+        File-backed PSS in MB
+    memory_pss_dirty
+        Dirty PSS in MB
+    memory_pss_shmem
+        Shared memory PSS in MB
+    memory_rss
+        Resident Set Size in MB
+    memory_shared_clean
+        Shared clean pages in MB
+    memory_shared_dirty
+        Shared dirty pages in MB
+    memory_private_clean
+        Private clean pages in MB
+    memory_private_dirty
+        Private dirty pages in MB
+    memory_referenced
+        Referenced pages in MB
+    memory_anonymous
+        Anonymous memory in MB
+    memory_lazyfree
+        LazyFree pages in MB
+    memory_anon_hugepages
+        Anonymous huge pages in MB
+    memory_shmem_pmd_mapped
+        Shared memory PMD mapped pages in MB
+    memory_file_pmd_mapped
+        File-backed PMD mapped pages in MB
+    memory_shared_hugetlb
+        Shared hugetlb pages in MB
+    memory_private_hugetlb
+        Private hugetlb pages in MB
+    memory_swap
+        Swap in MB
+    memory_swappss
+        Proportional Swap usage in MB
+    memory_locked
+        Locked pages in MB
 
     """
 
@@ -190,6 +316,29 @@ class ServiceStats(TypedDict):
     memory: float
     cpu: float
     pid_stats: dict[int, PIDStats]
+    memory_real_pss: float
+    memory_real: float
+    memory_pss: float
+    memory_pss_anon: float
+    memory_pss_file: float
+    memory_pss_dirty: float
+    memory_pss_shmem: float
+    memory_rss: float
+    memory_shared_clean: float
+    memory_shared_dirty: float
+    memory_private_clean: float
+    memory_private_dirty: float
+    memory_referenced: float
+    memory_anonymous: float
+    memory_lazyfree: float
+    memory_anon_hugepages: float
+    memory_shmem_pmd_mapped: float
+    memory_file_pmd_mapped: float
+    memory_shared_hugetlb: float
+    memory_private_hugetlb: float
+    memory_swap: float
+    memory_swappss: float
+    memory_locked: float
 
 
 class ServiceDeviceEntry(TypedDict):
@@ -242,6 +391,8 @@ class ServiceEntry(TypedDict):
         The device the sensor is attributed to
     device_class
         The device class of the sensor
+    entity_category
+        The entity category of the sensor
     state_topic
         The topic containing all information for the attributes of the sensor
     qos
@@ -262,5 +413,6 @@ class ServiceEntry(TypedDict):
     payload_off: str | None
     device: ServiceDeviceEntry
     device_class: str | None
+    entity_category: str | None
     json_attributes_topic: str | None
     qos: int


### PR DESCRIPTION
At the moment, the memory metric is based only on virtual memory (VmSize), which is misleading in most cases. Virtual memory includes all address space mappings of the process — anonymous allocations, shared libraries, file-backed mappings, and even regions that are never actually loaded into physical RAM. As a result, VmSize often reports extremely large values that do not reflect the real memory footprint of a process. For example, my torrent client shows more than 8 GB of virtual memory usage, while in reality the system as a whole only uses around 2 GB of RAM. This makes VmSize unsuitable for monitoring or comparing services, since it exaggerates memory usage and hides the actual resources consumed.

This commit introduces additional memory statistics based on /proc/<pid>/smaps_rollup:
- memory_real_pss: proportional set size (shared pages divided among processes), representing the actual memory footprint of the service.
- memory_real: conservative estimate of memory that will be freed if the process exits, based on Anonymous + SwapPss, excluding file-backed shared pages.

<img width="1323" height="786" alt="image" src="https://github.com/user-attachments/assets/03f22a64-69b5-4f6a-85d1-847a0d8035f1" />

These new metrics provide a more accurate view of real memory usage compared to the traditional RSS and virtual memory fields.

smaps-based metrics are disabled by default and can be enabled with the `--smaps` option.