### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
 
   check_version:
     name: Check the version
+    permissions:
+      contents: read
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
       - build


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/systemctl2mqtt/security/code-scanning/5](https://github.com/miaucl/systemctl2mqtt/security/code-scanning/5)

The recommended fix is to explicitly add a `permissions` block to the `check_version` job in `.github/workflows/publish.yml`, restricting its permissions to the minimum necessary—here, `contents: read`. This ensures the job cannot inadvertently write to the repository or perform any privileged actions with the default `GITHUB_TOKEN`. You must add the following block below the job's name and before its environment/steps:  
```yaml
permissions:
  contents: read
```  
This edit should be made under `check_version`, after line 35.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
