### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/systemctl2mqtt/security/code-scanning/3](https://github.com/miaucl/systemctl2mqtt/security/code-scanning/3)

To address this issue, add an explicit `permissions` block to the `build` job in `.github/workflows/publish.yml`. Since the `build` job only builds, installs, and uploads artifacts (and does not need to write to the repository or interact with issues/pulls/etc.), it should require only minimal permissions. The correct approach is to set `permissions: { contents: read }` for this job. This ensures least-privilege operation and satisfies both CodeQL and security recommendations. No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
